### PR TITLE
fix: make env.frontend fields generate from config

### DIFF
--- a/docker/config-example.toml
+++ b/docker/config-example.toml
@@ -73,3 +73,12 @@ L2_TX_FEE_VAULT = "0x5300000000000000000000000000000000000005"
 [coordinator]
 
 COORDINATOR_JWT_SECRET_KEY = "e788b62d39254928a821ac1c76b274a8c835aa1e20ecfb6f50eb10e87847de44"
+
+[frontend]
+
+EXTERNAL_RPC_URI_L1 ="http://l1-devnet.scrollsdk"
+EXTERNAL_RPC_URI_L2 = "http://l2-rpc.scrollsdk"
+BRIDGE_API_URI = "http://bridge-history-api.scrollsdk/api"
+ROLLUPSCAN_API_URI = "https://rollup-explorer-backend.scrollsdk/api"
+EXTERNAL_EXPLORER_URI_L1 = "http://l1-explorer.scrollsdk"
+EXTERNAL_EXPLORER_URI_L2 = "http://blockscout.scrollsdk"

--- a/scripts/deterministic/Configuration.sol
+++ b/scripts/deterministic/Configuration.sol
@@ -74,6 +74,14 @@ abstract contract Configuration is Script {
     // coordinator
     string internal COORDINATOR_JWT_SECRET_KEY;
 
+    // frontend
+    string internal REACT_APP_EXTERNAL_RPC_URI_L1;
+    string internal REACT_APP_EXTERNAL_RPC_URI_L2;
+    string internal REACT_APP_BRIDGE_API_URI;
+    string internal REACT_APP_ROLLUPSCAN_API_URI;
+    string internal REACT_APP_EXTERNAL_EXPLORER_URI_L1;
+    string internal REACT_APP_EXTERNAL_EXPLORER_URI_L2;
+
     /***************
      * Constructor *
      ***************/
@@ -132,6 +140,13 @@ abstract contract Configuration is Script {
         L1_PLONK_VERIFIER_ADDR = cfg.readAddress(".contracts.L1_PLONK_VERIFIER_ADDR");
 
         COORDINATOR_JWT_SECRET_KEY = cfg.readString(".coordinator.COORDINATOR_JWT_SECRET_KEY");
+
+        REACT_APP_EXTERNAL_RPC_URI_L1 = cfg.readString(".frontend.REACT_APP_EXTERNAL_RPC_URI_L1");
+        REACT_APP_EXTERNAL_RPC_URI_L2 = cfg.readString(".frontend.REACT_APP_EXTERNAL_RPC_URI_L2");
+        REACT_APP_BRIDGE_API_URI = cfg.readString(".frontend.REACT_APP_BRIDGE_API_URI");
+        REACT_APP_ROLLUPSCAN_API_URI = cfg.readString(".frontend.REACT_APP_ROLLUPSCAN_API_URI");
+        REACT_APP_EXTERNAL_EXPLORER_URI_L1 = cfg.readString(".frontend.REACT_APP_EXTERNAL_EXPLORER_URI_L1");
+        REACT_APP_EXTERNAL_EXPLORER_URI_L2 = cfg.readString(".frontend.REACT_APP_EXTERNAL_EXPLORER_URI_L2");
 
         runSanityCheck();
     }

--- a/scripts/deterministic/Configuration.sol
+++ b/scripts/deterministic/Configuration.sol
@@ -75,12 +75,12 @@ abstract contract Configuration is Script {
     string internal COORDINATOR_JWT_SECRET_KEY;
 
     // frontend
-    string internal REACT_APP_EXTERNAL_RPC_URI_L1;
-    string internal REACT_APP_EXTERNAL_RPC_URI_L2;
-    string internal REACT_APP_BRIDGE_API_URI;
-    string internal REACT_APP_ROLLUPSCAN_API_URI;
-    string internal REACT_APP_EXTERNAL_EXPLORER_URI_L1;
-    string internal REACT_APP_EXTERNAL_EXPLORER_URI_L2;
+    string internal EXTERNAL_RPC_URI_L1;
+    string internal EXTERNAL_RPC_URI_L2;
+    string internal BRIDGE_API_URI;
+    string internal ROLLUPSCAN_API_URI;
+    string internal EXTERNAL_EXPLORER_URI_L1;
+    string internal EXTERNAL_EXPLORER_URI_L2;
 
     /***************
      * Constructor *
@@ -141,12 +141,12 @@ abstract contract Configuration is Script {
 
         COORDINATOR_JWT_SECRET_KEY = cfg.readString(".coordinator.COORDINATOR_JWT_SECRET_KEY");
 
-        REACT_APP_EXTERNAL_RPC_URI_L1 = cfg.readString(".frontend.REACT_APP_EXTERNAL_RPC_URI_L1");
-        REACT_APP_EXTERNAL_RPC_URI_L2 = cfg.readString(".frontend.REACT_APP_EXTERNAL_RPC_URI_L2");
-        REACT_APP_BRIDGE_API_URI = cfg.readString(".frontend.REACT_APP_BRIDGE_API_URI");
-        REACT_APP_ROLLUPSCAN_API_URI = cfg.readString(".frontend.REACT_APP_ROLLUPSCAN_API_URI");
-        REACT_APP_EXTERNAL_EXPLORER_URI_L1 = cfg.readString(".frontend.REACT_APP_EXTERNAL_EXPLORER_URI_L1");
-        REACT_APP_EXTERNAL_EXPLORER_URI_L2 = cfg.readString(".frontend.REACT_APP_EXTERNAL_EXPLORER_URI_L2");
+        EXTERNAL_RPC_URI_L1 = cfg.readString(".frontend.EXTERNAL_RPC_URI_L1");
+        EXTERNAL_RPC_URI_L2 = cfg.readString(".frontend.EXTERNAL_RPC_URI_L2");
+        BRIDGE_API_URI = cfg.readString(".frontend.BRIDGE_API_URI");
+        ROLLUPSCAN_API_URI = cfg.readString(".frontend.ROLLUPSCAN_API_URI");
+        EXTERNAL_EXPLORER_URI_L1 = cfg.readString(".frontend.EXTERNAL_EXPLORER_URI_L1");
+        EXTERNAL_EXPLORER_URI_L2 = cfg.readString(".frontend.EXTERNAL_EXPLORER_URI_L2");
 
         runSanityCheck();
     }

--- a/scripts/deterministic/GenerateConfigs.s.sol
+++ b/scripts/deterministic/GenerateConfigs.s.sol
@@ -279,12 +279,12 @@ contract GenerateFrontendConfig is DeployScroll {
 
         // API endpoints
         vm.writeLine(FRONTEND_ENV_PATH, "");
-        vm.writeLine(FRONTEND_ENV_PATH, string.concat("REACT_APP_EXTERNAL_RPC_URI_L1 = \"", REACT_APP_EXTERNAL_RPC_URI_L1, "\""));
-        vm.writeLine(FRONTEND_ENV_PATH, string.concat("REACT_APP_EXTERNAL_RPC_URI_L2 = \"", REACT_APP_EXTERNAL_RPC_URI_L2, "\""));
-        vm.writeLine(FRONTEND_ENV_PATH, string.concat("REACT_APP_BRIDGE_API_URI = \"", REACT_APP_BRIDGE_API_URI, "\""));
-        vm.writeLine(FRONTEND_ENV_PATH, string.concat("REACT_APP_ROLLUPSCAN_API_URI = \"", REACT_APP_ROLLUPSCAN_API_URI, "\""));
-        vm.writeLine(FRONTEND_ENV_PATH, string.concat("REACT_APP_EXTERNAL_EXPLORER_URI_L1 = \"", REACT_APP_EXTERNAL_EXPLORER_URI_L1, "\""));
-        vm.writeLine(FRONTEND_ENV_PATH, string.concat("REACT_APP_EXTERNAL_EXPLORER_URI_L2 = \"", REACT_APP_EXTERNAL_EXPLORER_URI_L2, "\""));
+        vm.writeLine(FRONTEND_ENV_PATH, string.concat("REACT_APP_EXTERNAL_RPC_URI_L1 = \"", EXTERNAL_RPC_URI_L1, "\""));
+        vm.writeLine(FRONTEND_ENV_PATH, string.concat("REACT_APP_EXTERNAL_RPC_URI_L2 = \"", EXTERNAL_RPC_URI_L2, "\""));
+        vm.writeLine(FRONTEND_ENV_PATH, string.concat("REACT_APP_BRIDGE_API_URI = \"", BRIDGE_API_URI, "\""));
+        vm.writeLine(FRONTEND_ENV_PATH, string.concat("REACT_APP_ROLLUPSCAN_API_URI = \"", ROLLUPSCAN_API_URI, "\""));
+        vm.writeLine(FRONTEND_ENV_PATH, string.concat("REACT_APP_EXTERNAL_EXPLORER_URI_L1 = \"", EXTERNAL_EXPLORER_URI_L1, "\""));
+        vm.writeLine(FRONTEND_ENV_PATH, string.concat("REACT_APP_EXTERNAL_EXPLORER_URI_L2 = \"", EXTERNAL_EXPLORER_URI_L2, "\""));
 
         // L1 contracts
         vm.writeLine(FRONTEND_ENV_PATH, "");

--- a/scripts/deterministic/GenerateConfigs.s.sol
+++ b/scripts/deterministic/GenerateConfigs.s.sol
@@ -279,12 +279,12 @@ contract GenerateFrontendConfig is DeployScroll {
 
         // API endpoints
         vm.writeLine(FRONTEND_ENV_PATH, "");
-        vm.writeLine(FRONTEND_ENV_PATH, "REACT_APP_EXTERNAL_RPC_URI_L1 = \"http://l1-devnet.scrollsdk\"");
-        vm.writeLine(FRONTEND_ENV_PATH, "REACT_APP_EXTERNAL_RPC_URI_L2 = \"http://l2-rpc.scrollsdk\"");
-        vm.writeLine(FRONTEND_ENV_PATH, "REACT_APP_BRIDGE_API_URI = \"http://bridge-history-api.scrollsdk/api\"");
-        vm.writeLine(FRONTEND_ENV_PATH, "REACT_APP_ROLLUPSCAN_API_URI = \"https://rollup-explorer-backend.scrollsdk/api\"");
-        vm.writeLine(FRONTEND_ENV_PATH, "REACT_APP_EXTERNAL_EXPLORER_URI_L1 = \"http://l1-explorer.scrollsdk\"");
-        vm.writeLine(FRONTEND_ENV_PATH, "REACT_APP_EXTERNAL_EXPLORER_URI_L2 = \"http://blockscout.scrollsdk\"");
+        vm.writeLine(FRONTEND_ENV_PATH, string.concat("REACT_APP_EXTERNAL_RPC_URI_L1 = \"", REACT_APP_EXTERNAL_RPC_URI_L1, "\""));
+        vm.writeLine(FRONTEND_ENV_PATH, string.concat("REACT_APP_EXTERNAL_RPC_URI_L2 = \"", REACT_APP_EXTERNAL_RPC_URI_L2, "\""));
+        vm.writeLine(FRONTEND_ENV_PATH, string.concat("REACT_APP_BRIDGE_API_URI = \"", REACT_APP_BRIDGE_API_URI, "\""));
+        vm.writeLine(FRONTEND_ENV_PATH, string.concat("REACT_APP_ROLLUPSCAN_API_URI = \"", REACT_APP_ROLLUPSCAN_API_URI, "\""));
+        vm.writeLine(FRONTEND_ENV_PATH, string.concat("REACT_APP_EXTERNAL_EXPLORER_URI_L1 = \"", REACT_APP_EXTERNAL_EXPLORER_URI_L1, "\""));
+        vm.writeLine(FRONTEND_ENV_PATH, string.concat("REACT_APP_EXTERNAL_EXPLORER_URI_L2 = \"", REACT_APP_EXTERNAL_EXPLORER_URI_L2, "\""));
 
         // L1 contracts
         vm.writeLine(FRONTEND_ENV_PATH, "");


### PR DESCRIPTION
Problem:
Fields like "REACT_APP_EXTERNAL_RPC_URI_L1" in .env.frontend file are hardcoded, not configurable.

Solution:
Modify scripts/deterministic/GenerateConfigs.s.sol to enable read those fields from config.toml file.