### PR TITLE
feat: log broadcast files

### DIFF
--- a/docker/scripts/deploy.sh
+++ b/docker/scripts/deploy.sh
@@ -22,6 +22,14 @@ if [ "${BATCH_SIZE}" = "" ]; then
     BATCH_SIZE="100"
 fi
 
+if [ "${CHAIN_ID_L1}" = "" ]; then
+    CHAIN_ID_L1="111111"
+fi
+
+if [ "${CHAIN_ID_L2}" = "" ]; then
+    CHAIN_ID_L2="221122"
+fi
+
 echo "using L1_RPC_ENDPOINT = $L1_RPC_ENDPOINT"
 echo "using L2_RPC_ENDPOINT = $L2_RPC_ENDPOINT"
 
@@ -44,3 +52,13 @@ forge script scripts/deterministic/DeployScroll.s.sol:DeployScroll --rpc-url "$L
 echo ""
 echo "deploying on L2"
 forge script scripts/deterministic/DeployScroll.s.sol:DeployScroll --rpc-url "$L2_RPC_ENDPOINT"  --batch-size "$BATCH_SIZE" --sig "run(string,string)" "L2" "verify-config" --broadcast --legacy || exit 1
+
+# log L1 broadcast file
+echo ""
+echo "L1 broadcast file:"
+cat broadcast/DeployScroll.s.sol/$CHAIN_ID_L1/run-latest.json
+
+# log L2 broadcast file
+echo ""
+echo "L2 broadcast file:"
+cat broadcast/DeployScroll.s.sol/$CHAIN_ID_L2/run-latest.json


### PR DESCRIPTION
Problem:
Some of clients want log files of the contracts that were successfully deployed, so they could get to know the contracts deployment process in detail.

Solution:
Foundry do provide a file -- broadcast/DeployScroll.s.sol/$CHAIN_ID_L1/run-latest.json to cache deployment information.
It doable to persist the file to a node, but kubernetes is supposed to be a cluster of machines, so it will be rather complex to get it.
**So here we cat broadcast files in docker, this would be easy to implement, and client shall get those information in deploy-contracts pod logs.**