### PR TITLE
fix: log addresses script mode

### DIFF
--- a/scripts/deterministic/DeterministicDeployment.sol
+++ b/scripts/deterministic/DeterministicDeployment.sol
@@ -72,7 +72,7 @@ abstract contract DeterminsticDeployment is Configuration {
 
     function setScriptMode(string memory scriptMode) internal {
         if (keccak256(bytes(scriptMode)) == keccak256(bytes("log-addresses"))) {
-            mode = ScriptMode.WriteConfig;
+            mode = ScriptMode.LogAddresses;
         } else if (keccak256(bytes(scriptMode)) == keccak256(bytes("write-config"))) {
             mode = ScriptMode.WriteConfig;
         } else if (keccak256(bytes(scriptMode)) == keccak256(bytes("verify-config"))) {


### PR DESCRIPTION
Fix function setScriptMode() in ./scripts/deterministic/DeterministicDeployment.sol set ScriptMode to WriteConfig when pass "log-addresses" as paremeter.