### PR TITLE
fix: generate startHeight for bridge-history config

### DIFF
--- a/docker/templates/bridge-history-config.json
+++ b/docker/templates/bridge-history-config.json
@@ -2,7 +2,7 @@
   "L1": {
     "confirmation": 0,
     "endpoint": null,
-    "startHeight": 0,
+    "startHeight": null,
     "blockTime": 12,
     "fetchLimit": 16,
     "MessageQueueAddr": null,

--- a/scripts/deterministic/GenerateConfigs.s.sol
+++ b/scripts/deterministic/GenerateConfigs.s.sol
@@ -203,6 +203,7 @@ contract GenerateBridgeHistoryConfig is DeployScroll {
 
         // others
         vm.writeJson(BRIDGE_HISTORY_DB_CONNECTION_STRING, BRIDGE_HISTORY_CONFIG_PATH, ".db.dsn");
+        vm.writeJson(vm.toString(L1_CONTRACT_DEPLOYMENT_BLOCK), BRIDGE_HISTORY_CONFIG_PATH, ".L1.startHeight");
     }
 }
 


### PR DESCRIPTION
generate startHeight for bridge-history config from config.toml, to prevent bridge history fetch takes too long to sync l1 event.