### PR TITLE
test: add solidity test coverage

### DIFF
--- a/src/test/ETHRateLimiter.t.sol
+++ b/src/test/ETHRateLimiter.t.sol
@@ -17,6 +17,12 @@ contract ETHRateLimiterTest is DSTestPlus {
         limiter = new ETHRateLimiter(86400, address(this), 100 ether);
     }
 
+    function testDeployRateLimiterRevert() external {
+        // periodDuration is zero, should revert
+        hevm.expectRevert(IETHRateLimiter.PeriodIsZero.selector);
+        new ETHRateLimiter(0, address(this), 100 ether);
+    }
+
     function testUpdateTotalLimit(uint104 _newTotalLimit) external {
         hevm.assume(_newTotalLimit > 0);
 

--- a/src/test/ScrollStandardERC20Factory.t.sol
+++ b/src/test/ScrollStandardERC20Factory.t.sol
@@ -17,6 +17,12 @@ contract ScrollStandardERC20FactoryTest is DSTestPlus {
         factory = new ScrollStandardERC20Factory(address(impl));
     }
 
+    function testDeployFactoryRevert() external {
+        // zero address as ERC20 implementation address, revert
+        hevm.expectRevert("zero implementation address");
+        new ScrollStandardERC20Factory(address(0));
+    }
+
     function testDeployL2Token(address _gateway, address _l1Token) external {
         // call by non-owner, should revert
         hevm.startPrank(address(1));

--- a/src/test/TokenRateLimiter.t.sol
+++ b/src/test/TokenRateLimiter.t.sol
@@ -17,6 +17,12 @@ contract TokenRateLimiterTest is DSTestPlus {
         limiter = new TokenRateLimiter(86400);
     }
 
+    function testDeployRateLimiterRevert() external {
+        // periodDuration is zero, should revert
+        hevm.expectRevert(ITokenRateLimiter.PeriodIsZero.selector);
+        new TokenRateLimiter(0);
+    }
+
     function testUpdateTotalLimit(address _token, uint104 _newTotalLimit) external {
         hevm.assume(_newTotalLimit > 0);
 


### PR DESCRIPTION
Follow up to [this](https://github.com/scroll-tech/scroll/pull/1388)

Added a small bit of coverage to ScrollStandardERC20Factory.sol, ETHRateLimiter.sol and TokenRateLimiter.sol, bringing all three to 100% coverage.