### PR TITLE
ci: fix TOB-SCREUC-6, disable cache-binary option

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -31,6 +31,8 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
+        with:
+          cache-binary: false
 
       - name: Login to Dockerhub
         uses: docker/login-action@v2


### PR DESCRIPTION
Fix [zizmor](https://github.com/woodruffw/zizmor) error:

```
error[cache-poisoning]: runtime artifacts potentially vulnerable to a cache poisoning attack
  --> .github/workflows/docker-release.yml:45:9
   |
33 |         uses: docker/setup-buildx-action@v2
   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ cache enabled by default here
34 |
...
44 |           REPOSITORY: scrolltech/scroll-stack-contracts
45 |         uses: docker/build-push-action@v3
   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ runtime artifacts usually published here
   |
   = note: audit confidence → Low
```