### PR TITLE
add callback back in L1ERC20GatewayValidium.finalizeWithdrawERC20

### DIFF
--- a/src/validium/L1ERC20GatewayValidium.sol
+++ b/src/validium/L1ERC20GatewayValidium.sol
@@ -139,6 +139,8 @@ contract L1ERC20GatewayValidium is ScrollGatewayBase, IL1ERC20GatewayValidium {
 
         IERC20Upgradeable(_l1Token).safeTransfer(_to, _amount);
 
+        _doCallback(_to, _data);
+
         emit FinalizeWithdrawERC20(_l1Token, _l2Token, _from, _to, _amount, _data);
     }
 


### PR DESCRIPTION
This PR reintroduces the missing `_doCallback(_to, _data)` call in `L1ERC20GatewayValidium.finalizeWithdrawERC20`, ensuring that recipient callbacks are executed during ERC20 withdrawal finalization in the validium gateway. This restores expected behavior for contracts and recipients that rely on callback execution when processing withdrawals.